### PR TITLE
Adding ICTT OpenZeppelin Audit - July 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - [Louis Teleporter Audit (October 20th 2023)](./teleporter/Teleporter_Audit_October_20_2023_Louis.pdf)
 - [Louis Teleporter Upgradeable Audit (January 10th 2024)](./teleporter/Teleporter_Upgradeable_Audit_January_10th_2024_Louis.pdf)
 
-## Interchain Token Transfer
+### Interchain Token Transfer
 - [OpenZeppelin Interchain Token Transfer Audit (July 3rd 2024)](./teleporter/Interchain_Token_Transfer_Audit_July_3_2024_OpenZeppelin.pdf)
 
 ## Wallet SDK

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@
 ## Teleporter
 
 - [Least Authority - Ava Labs Bridge Smart Contracts Final Audit Report (July 7th 2023)](./teleporter/Least_Authority_Ava_Labs_Bridge_Smart_Contracts_Final_Audit_Report.pdf)
-- [Teleporter Audit (November 16th 2023) - OpenZeppelin](./teleporter/Teleporter_Audit_November_16th_2023_OpenZeppelin.pdf)
-- [Teleporter Audit (October 20 2023) - Louis](./teleporter/Teleporter_Audit_October_20_2023_Louis.pdf)
-- [Teleporter Upgradeable Audit (January 10th 2024) - Louis](./teleporter/Teleporter_Upgradeable_Audit_January_10th_2024_Louis.pdf)
+- [OpenZeppelin Teleporter Audit (November 16th 2023)](./teleporter/Teleporter_Audit_November_16th_2023_OpenZeppelin.pdf)
+- [Louis Teleporter Audit (October 20th 2023)](./teleporter/Teleporter_Audit_October_20_2023_Louis.pdf)
+- [Louis Teleporter Upgradeable Audit (January 10th 2024)](./teleporter/Teleporter_Upgradeable_Audit_January_10th_2024_Louis.pdf)
+
+## Interchain Token Transfer
+- [OpenZeppelin Interchain Token Transfer Audit (July 3rd 2024)](./teleporter/Interchain_Token_Transfer_Audit_July_3_2024_OpenZeppelin.pdf)
 
 ## Wallet SDK
 


### PR DESCRIPTION
Added pdf to Teleporter folder, and section in README for Interchain Token Transfer (ICTT) OpenZeppelin audit from July 3rd, 2024.